### PR TITLE
Create one scheme that builds and tests targets instead of two schemes, one for building, and one for testing 

### DIFF
--- a/src/TulsiGenerator/XcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/XcodeProjectGenerator.swift
@@ -964,10 +964,10 @@ final class XcodeProjectGenerator {
         // Foo
         // FooTests
         //
-        // By removing `Tests` from the second scheme, the first gets dropped, and only the second, test, scheme
-        // gets returned.
-        // Command + B on this scheme = build target and tests
-        // Command + U on this scheme = runs the tests
+        // By removing `Tests` suffix from the second scheme (FooTests), the first scheme gets de-duped,
+        // and only the second (FooTests -> Foo) scheme gets returned.
+        // Command + B on the returned scheme => build target and tests
+        // Command + U on the returned scheme => runs the tests
         filename += target.name.replacingOccurrences(of: "Tests", with: "") + ".xcscheme"
         let url = xcschemesURL.appendingPathComponent(filename)
 

--- a/src/TulsiGenerator/XcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/XcodeProjectGenerator.swift
@@ -943,6 +943,7 @@ final class XcodeProjectGenerator {
                                  project: info.project,
                                  projectBundleName: projectBundleName,
                                  testActionBuildConfig: runTestTargetBuildConfigPrefix + "Debug",
+                                 launchActionBuildConfig: runTestTargetBuildConfigPrefix + "Debug",
                                  profileActionBuildConfig: runTestTargetBuildConfigPrefix + "Release",
                                  appExtension: appExtension,
                                  extensionType: extensionType,

--- a/src/TulsiGenerator/XcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/XcodeProjectGenerator.swift
@@ -957,7 +957,17 @@ final class XcodeProjectGenerator {
                                  localizedMessageLogger: localizedMessageLogger)
         let xmlDocument = scheme.toXML()
 
-        filename += target.name + ".xcscheme"
+        // By removing "Tests" from the name of the scheme, we only return 1 scheme per target + test target
+        // Previously, there would be two schemes:
+        //
+        // Foo
+        // FooTests
+        //
+        // By removing `Tests` from the second scheme, the first gets dropped, and only the second, test, scheme
+        // gets returned.
+        // Command + B on this scheme = build target and tests
+        // Command + U on this scheme = runs the tests
+        filename += target.name.replacingOccurrences(of: "Tests", with: "") + ".xcscheme"
         let url = xcschemesURL.appendingPathComponent(filename)
 
         let data = xmlDocument.xmlData(options: XMLNode.Options.nodePrettyPrint)


### PR DESCRIPTION
        
       // By removing "Tests" from the name of the scheme, we only return 1 scheme per target + test target
        // Previously, there would be two schemes:
        //
        // Foo
        // FooTests
        //
        // By removing `Tests` from the second scheme, the first gets dropped, and only the second, test, scheme
        // gets returned.
        // Command + B on this scheme = build target and tests
        // Command + U on this scheme = runs the tests