### PR TITLE
[MOBDEVXP-2305] Force x86_64 on arm64 (M1s)

### DIFF
--- a/src/TulsiGenerator/DeploymentTarget.swift
+++ b/src/TulsiGenerator/DeploymentTarget.swift
@@ -36,7 +36,7 @@ public enum CPU: String {
     case .arm64: return true
     case .arm64e: return true
     case .arm64_32: return true
-    case .sim_arm64: return true
+    case .sim_arm64: return false
     }
   }
 


### PR DESCRIPTION
This is a brute-force change that is only "correct" for projects such as Slack that require x86_64 for simulator development.

It is simple, however, and effective without adding additional settings and complexity.

The downstream effect of this change is the Bazel invocation will pass `--cpu=ios_x86_64` when building for simulator, instead of `ios_arm64`